### PR TITLE
use less specific argument type

### DIFF
--- a/lib/CryptoBridge/Crypto.php
+++ b/lib/CryptoBridge/Crypto.php
@@ -6,7 +6,7 @@ namespace Sop\CryptoBridge;
 
 use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\CipherAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Feature\SignatureAlgorithmIdentifier;
-use Sop\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use Sop\CryptoTypes\Asymmetric\OneAsymmetricKey;
 use Sop\CryptoTypes\Asymmetric\PublicKeyInfo;
 use Sop\CryptoTypes\Signature\Signature;
 
@@ -19,12 +19,12 @@ abstract class Crypto
      * Sign data with given algorithm using given private key.
      *
      * @param string                       $data         Data to sign
-     * @param PrivateKeyInfo               $privkey_info Private key
+     * @param OneAsymmetricKey             $privkey_info Private key
      * @param SignatureAlgorithmIdentifier $algo         Signature algorithm
      *
      * @return Signature
      */
-    abstract public function sign(string $data, PrivateKeyInfo $privkey_info,
+    abstract public function sign(string $data, OneAsymmetricKey $privkey_info,
         SignatureAlgorithmIdentifier $algo): Signature;
 
     /**

--- a/lib/CryptoBridge/Crypto/OpenSSLCrypto.php
+++ b/lib/CryptoBridge/Crypto/OpenSSLCrypto.php
@@ -10,7 +10,7 @@ use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\BlockCipherAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\CipherAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\RC2CBCAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Feature\SignatureAlgorithmIdentifier;
-use Sop\CryptoTypes\Asymmetric\PrivateKeyInfo;
+use Sop\CryptoTypes\Asymmetric\OneAsymmetricKey;
 use Sop\CryptoTypes\Asymmetric\PublicKeyInfo;
 use Sop\CryptoTypes\Signature\Signature;
 
@@ -59,7 +59,7 @@ class OpenSSLCrypto extends Crypto
     /**
      * {@inheritdoc}
      */
-    public function sign(string $data, PrivateKeyInfo $privkey_info,
+    public function sign(string $data, OneAsymmetricKey $privkey_info,
         SignatureAlgorithmIdentifier $algo): Signature
     {
         $this->_checkSignatureAlgoAndKey($algo, $privkey_info->algorithmIdentifier());


### PR DESCRIPTION
You can't get an instance of `PublicKeyInfo` very easily since e.g. `PublicKeyInfo::fromPEM()` returns an instance of `OneAsymmetricKey`. Since both classes are identical, just use the less specific one.